### PR TITLE
fix: make hkdf key non extractable

### DIFF
--- a/src/key_seal/wasm/symmetric_key.rs
+++ b/src/key_seal/wasm/symmetric_key.rs
@@ -44,6 +44,7 @@ impl PlainKey for SymmetricKey {
             // Note: Not sure if algorithm or uses are required for our purposes,
             // but the web crypto API requires them as arguments.
             "AES-KW",
+            true,
             &["wrapKey", "unwrapKey"],
         )
         .await?;


### PR DESCRIPTION
FIxes unnecessary setting of HKDF key to extractable. This was causing tests to fail in Chrome.